### PR TITLE
Switch to static linking

### DIFF
--- a/PROJECT_HS.vcxproj
+++ b/PROJECT_HS.vcxproj
@@ -138,6 +138,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
This pull request includes a small change to the `PROJECT_HS.vcxproj` file. The change specifies the use of the MultiThreaded runtime library for the project.

* [`PROJECT_HS.vcxproj`](diffhunk://#diff-0313c18bfd98b3f8706b136b64477b7bd1a025582fab85ff9ced62991757526eR141): Added `<RuntimeLibrary>MultiThreaded</RuntimeLibrary>` to the ClCompile section.

* Users no longer have to install the C++ development pack in Visual Studio to be able to inject.